### PR TITLE
Replace log with logrus

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vsphere/config_test.go
+++ b/vsphere/config_test.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"strconv"

--- a/vsphere/data_source_vsphere_dynamic.go
+++ b/vsphere/data_source_vsphere_dynamic.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/data_source_vsphere_host_pci_device.go
+++ b/vsphere/data_source_vsphere_host_pci_device.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strconv"
 

--- a/vsphere/data_source_vsphere_license.go
+++ b/vsphere/data_source_vsphere_license.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/govmomi/license"

--- a/vsphere/data_source_vsphere_role.go
+++ b/vsphere/data_source_vsphere_role.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/distributed_virtual_port_setting_structure.go
+++ b/vsphere/distributed_virtual_port_setting_structure.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/distributed_virtual_switch_structure.go
+++ b/vsphere/distributed_virtual_switch_structure.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/internal/helper/clustercomputeresource/cluster_compute_resource_helper.go
+++ b/vsphere/internal/helper/clustercomputeresource/cluster_compute_resource_helper.go
@@ -6,7 +6,7 @@ package clustercomputeresource
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -6,7 +6,7 @@ package computeresource
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"

--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vsphere/internal/helper/datastore/datastore_helper.go
+++ b/vsphere/internal/helper/datastore/datastore_helper.go
@@ -6,7 +6,7 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25"

--- a/vsphere/internal/helper/folder/folder_helper.go
+++ b/vsphere/internal/helper/folder/folder_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 	"strings"
 

--- a/vsphere/internal/helper/hostsystem/host_system_helper.go
+++ b/vsphere/internal/helper/hostsystem/host_system_helper.go
@@ -6,7 +6,7 @@ package hostsystem
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vsphere/internal/helper/resourcepool/resource_pool_helper.go
+++ b/vsphere/internal/helper/resourcepool/resource_pool_helper.go
@@ -6,7 +6,7 @@ package resourcepool
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/computeresource"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/spbm/spbm_helper.go
+++ b/vsphere/internal/helper/spbm/spbm_helper.go
@@ -6,7 +6,7 @@ package spbm
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/viapi"

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -6,7 +6,7 @@ package storagepod
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/datastore"

--- a/vsphere/internal/helper/utils/entityIdToManagedObjectId.go
+++ b/vsphere/internal/helper/utils/entityIdToManagedObjectId.go
@@ -5,7 +5,7 @@ package utils
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
 	"github.com/vmware/govmomi"

--- a/vsphere/internal/helper/vappcontainer/vappcontainer_helper.go
+++ b/vsphere/internal/helper/vappcontainer/vappcontainer_helper.go
@@ -5,7 +5,7 @@ package vappcontainer
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/vmware/govmomi"

--- a/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
+++ b/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
@@ -6,7 +6,7 @@ package virtualdisk
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"strconv"
 	"strings"

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -5,7 +5,7 @@ package virtualdevice
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"strconv"

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"path"
 	"reflect"

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -6,7 +6,7 @@ package virtualdevice
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -5,7 +5,7 @@ package vmworkflow
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_host_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_host_group.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_anti_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_dependency_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_compute_cluster_vm_group.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_group.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_compute_cluster_vm_host_rule.go
+++ b/vsphere/resource_vsphere_compute_cluster_vm_host_rule.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_content_library.go
+++ b/vsphere/resource_vsphere_content_library.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_content_library_item.go
+++ b/vsphere/resource_vsphere_content_library_item.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_datacenter.go
+++ b/vsphere/resource_vsphere_datacenter.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule.go
+++ b/vsphere/resource_vsphere_datastore_cluster_vm_anti_affinity_rule.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/resource_vsphere_dpm_host_override.go
+++ b/vsphere/resource_vsphere_dpm_host_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_drs_vm_override.go
+++ b/vsphere/resource_vsphere_drs_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_entity_permissions.go
+++ b/vsphere/resource_vsphere_entity_permissions.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vsphere/resource_vsphere_file.go
+++ b/vsphere/resource_vsphere_file.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 	"strings"
 	"time"

--- a/vsphere/resource_vsphere_folder_migrate.go
+++ b/vsphere/resource_vsphere_folder_migrate.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"

--- a/vsphere/resource_vsphere_ha_vm_override.go
+++ b/vsphere/resource_vsphere_ha_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
 

--- a/vsphere/resource_vsphere_license.go
+++ b/vsphere/resource_vsphere_license.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"context"
 

--- a/vsphere/resource_vsphere_resource_pool.go
+++ b/vsphere/resource_vsphere_resource_pool.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vsphere/resource_vsphere_role.go
+++ b/vsphere/resource_vsphere_role.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/vsphere/resource_vsphere_storage_drs_vm_override.go
+++ b/vsphere/resource_vsphere_storage_drs_vm_override.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_tag.go
+++ b/vsphere/resource_vsphere_tag.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vapp_container.go
+++ b/vsphere/resource_vsphere_vapp_container.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vapp_entity.go
+++ b/vsphere/resource_vsphere_vapp_entity.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"errors"

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"strings"

--- a/vsphere/resource_vsphere_virtual_machine_migrate.go
+++ b/vsphere/resource_vsphere_virtual_machine_migrate.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/vsphere/resource_vsphere_virtual_machine_snapshot.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vm_storage_policy.go
+++ b/vsphere/resource_vsphere_vm_storage_policy.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/resource_vsphere_vnic.go
+++ b/vsphere/resource_vsphere_vnic.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -6,7 +6,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -5,7 +5,7 @@ package vsphere
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 
 	"github.com/mitchellh/copystructure"

--- a/vsphere/virtual_machine_guest_structure.go
+++ b/vsphere/virtual_machine_guest_structure.go
@@ -4,7 +4,7 @@
 package vsphere
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sort"
 	"strings"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-vsphere', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
.release
scripts
.github
docs
acctests
website
.git
legacy
vsphere
workflows
ISSUE_TEMPLATE
equinix
vsphere
docs
r
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
65
20
99
eb
18
b6
e2
78
e6
66
b0
49
fe
01
57
89
5a
1e
e4
f5
d0
1c
44
95
72
dc
b7
ee
11
c8
22
1f
7a
47
5c
7c
07
fa
59
9e
75
52
8e
d6
96
ba
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ff
bf
dd
76
3e
34
60
1d
4c
05
ca
26
a4
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
0b
c1
a6
0f
93
61
5b
51
cf
d1
2a
f6
e9
pack
f7
ef
9a
8b
e8
d7
b3
ce
79
b5
f1
ae
be
28
a2
info
f8
80
ed
3c
9d
15
a5
56
c6
2b
fc
ad
09
d4
50
98
73
6d
f0
70
7e
bc
46
88
0c
c0
af
d5
a8
5e
35
16
aa
ab
41
e1
b9
6b
23
37
83
d3
54
0d
33
8f
d9
39
36
55
63
17
c4
92
68
f9
c3
38
2c
8a
b2
7b
32
6a
14
2d
cc
58
03
25
6f
86
62
df
4d
0a
13
30
90
refs
heads
tags
heads
scripts
acc_setup
init
testdata
internal
administrationroles
virtualdevice
helper
vmworkflow
virtualdisk
provider
hostsystem
computeresource
utils
nsx
clustercomputeresource
structure
resourcepool
network
storagepod
datastore
vsanclient
folder
vsansystem
envbrowse
dvportgroup
virtualmachine
ovfdeploy
customattribute
spbm
vappcontainer
contentlibrary
datacenter
testhelper
viapi

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)